### PR TITLE
info window closes when click anywhere on map not just x

### DIFF
--- a/public/scripts/controllers/map.controller.js
+++ b/public/scripts/controllers/map.controller.js
@@ -24,6 +24,10 @@ myApp.controller('MapCtrl', function($http, NgMap, $interval, $uibModal) {
     vm.map = map;
   });
 
+  vm.options = {
+    clickableIcons: "false"
+  };
+
 // detailed place info modal
   vm.clicked = function(place, size, parentSelector) {
     var parentElem = parentSelector;

--- a/public/views/pages/map.html
+++ b/public/views/pages/map.html
@@ -26,7 +26,7 @@
   </div>
 
   <div class="gmap">
-    <ng-map id="map" default-style="false" zoom="11" center="[45.1250, -92.6044]">
+    <ng-map id="map" default-style="false" zoom="11" center="[45.1250, -92.6044]" on-click="mc.map.hideInfoWindow('mapwindow')">
 
       <custom-marker id="x{{place.id}}" ng-if="mc.showDining" ng-repeat="place in mc.diningPins track by $index" position=[{{place.latitude}},{{place.longitude}}] on-click="mc.showDetail(place)">
         <div class="marker">

--- a/public/views/pages/map.html
+++ b/public/views/pages/map.html
@@ -26,7 +26,7 @@
   </div>
 
   <div class="gmap">
-    <ng-map id="map" default-style="false" zoom="11" center="[45.1250, -92.6044]" on-click="mc.map.hideInfoWindow('mapwindow')">
+    <ng-map id="map" default-style="false" zoom="11" center="[45.1250, -92.6044]" on-click="mc.map.hideInfoWindow('mapwindow')" options="{{mc.options}}">
 
       <custom-marker id="x{{place.id}}" ng-if="mc.showDining" ng-repeat="place in mc.diningPins track by $index" position=[{{place.latitude}},{{place.longitude}}] on-click="mc.showDetail(place)">
         <div class="marker">


### PR DESCRIPTION
got the info window to close when clicking anywhere on the map (and not just on the x in the info window).  small change but good UX win for us!

i added another commit -- figured out how to disable clickable icons.  rather than removing them all together (they are probably good UX in terms of map usability to be able to see other landmarks/schools/restaurants/etc on the map), this disables the info window so even if you click on a default google POI (point of interest) google marker, you don't get an info window.